### PR TITLE
Fix wrong function call to grab_images

### DIFF
--- a/cython/factory.pyx
+++ b/cython/factory.pyx
@@ -363,11 +363,11 @@ cdef class Camera:
 
 
     def grab_image(self, EGrabStrategy grab_strategy=GrabStrategy_OneByOne, unsigned int timeout=5000):
-        return next(self.grab_images(False, 1, grab_strategy, timeout))
+        return next(self._grab_images(False, 1, grab_strategy, timeout))
 
 
     def grab_chunked_image(self, EGrabStrategy grab_strategy=GrabStrategy_OneByOne, unsigned int timeout=5000):
-        return next(self.grab_images(True, 1, grab_strategy, timeout))
+        return next(self._grab_images(True, 1, grab_strategy, timeout))
 
 
     property properties:


### PR DESCRIPTION
The old function calls went to grab_images instead of _grab_images.
This caused a TypeError (grab_images takes 3 arguments, 4 were given).
It appears that the function call should instead go to the similarily
named function _grab_images.